### PR TITLE
Fixes count/counter typo in test_it_can_count_flags

### DIFF
--- a/complete_me/lib/node.rb
+++ b/complete_me/lib/node.rb
@@ -1,5 +1,7 @@
 class Node
-  attr_accessor :weight, :flag, :children
+  attr_accessor :weight, 
+                :flag, 
+                :children
 
   def initialize
     @weight = {}

--- a/complete_me/test/complete_me_test.rb
+++ b/complete_me/test/complete_me_test.rb
@@ -23,14 +23,13 @@ class CompleteMeTest < MiniTest::Test
   end
 
   def test_it_can_count_flags
-    skip
     @complete_me.insert("pize")
     @complete_me.insert("pizza")
     @complete_me.insert("pizzicato")
     @complete_me.insert("pizzle")
 
     expected = 4
-    actual = @complete_me.count
+    actual = @complete_me.counter
     
     assert_equal expected, actual
   end


### PR DESCRIPTION
Just needed to update the `counter` method call in a skipped test.